### PR TITLE
Brought back a guard to prevent the flush() function from being call …

### DIFF
--- a/src/runtime/internal/scheduler.ts
+++ b/src/runtime/internal/scheduler.ts
@@ -51,7 +51,9 @@ export function add_flush_callback(fn) {
 //    function, guarantees this behavior.
 const seen_callbacks = new Set();
 let flushidx = 0;  // Do *not* move this inside the flush() function
+let flushing = false;
 export function flush() {
+	if (flushing) return;
 	const saved_component = current_component;
 
 	do {
@@ -91,6 +93,7 @@ export function flush() {
 		flush_callbacks.pop()();
 	}
 
+	flushing = false;
 	update_scheduled = false;
 	seen_callbacks.clear();
 	set_current_component(saved_component);


### PR DESCRIPTION
This PR is created based on the [PR 7397](https://github.com/sveltejs/svelte/pull/).
